### PR TITLE
Replace property with flag in premake5.lua

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -17,10 +17,9 @@ solution "gluac"
 		kind	"ConsoleApp"
 		targetname "gluac"
 		
-		flags { "NoPCH" }
+		flags { "NoPCH", "StaticRuntime" }
 		symbols "On"
 		editandcontinue "Off"
-		staticruntime "On"
 		vectorextensions "SSE"
 
 		links "bootil_static"
@@ -52,10 +51,9 @@ solution "gluac"
 		kind "StaticLib"
 		targetname( "bootil_static" )
 
-		flags { "NoPCH" }
+		flags { "NoPCH", "StaticRuntime" }
 		symbols "On"
 		editandcontinue "Off"
-		staticruntime "On"
 		vectorextensions "SSE"
 
 		includedirs { "Bootil/include/", "Bootil/src/3rdParty/" }


### PR DESCRIPTION
Fixes this error on my machine:

```
Error: premake5.lua:23: attempt to call a nil value (global 'staticruntime')
```