### PR TITLE
Use binary mode since we return bytecode not text

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #include "io.h"
+#include <fcntl.h>
 #include "getopt_win.h"
 #else
 
@@ -119,6 +120,11 @@ static int lua_main(lua_State *L) {
 }
 
 int main(int argc, char *argv[]) {
+    #ifdef _WIN32
+      setmode(fileno(stdout),O_BINARY);
+      setmode(fileno(stdin),O_BINARY);
+    #endif
+    
     int opt = 0;
     while ((opt = getopt(argc, argv, "ps")) != -1) {
         switch (opt) {


### PR DESCRIPTION
Using the output of gluac makes the bytecode corrupted because of \r\n on Windows.
This PR changes streams to binary mode to prevent such problems.